### PR TITLE
Fix favicon for `Sutil` template, resolves #2

### DIFF
--- a/templates/Sutil/public/index.html
+++ b/templates/Sutil/public/index.html
@@ -4,7 +4,7 @@
   <title>Sutil SAFE</title>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="icon" type="image/png" href="/favicon.png"/>
+  <link rel="icon" type="image/x-icon" href="favicon.ico"/>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.9.2/css/bulma.min.css" integrity="sha512-byErQdWdTqREz6DLAA9pCnLbdoGGhXfU6gm1c8bkf7F51JVmUBlayGe2A31VpXWQP+eiJ3ilTAZHCR3vmMyybA==" crossorigin="anonymous" />
 </head>
 <body>


### PR DESCRIPTION
Resolves #2

Favicon for `Sutil` template was retrieved as `png` but it's in `ico` format. This changes `png` to `ico`.